### PR TITLE
Updated Thumbnail size from 256 to 264

### DIFF
--- a/app/client/src/main.js
+++ b/app/client/src/main.js
@@ -358,7 +358,7 @@ new Vue({
             navigator.mediaSession.setActionHandler('previoustrack', () => this.skip(-1));
         },
         //Get Deezer CDN image url
-        getImageUrl(img, size = 256) {
+        getImageUrl(img, size = 264) {
             return `https://e-cdns-images.dzcdn.net/images/${img.type}/${img.hash}/${size}x${size}-000000-80-0-0.jpg`
         },
 

--- a/app/src/definitions.js
+++ b/app/src/definitions.js
@@ -134,9 +134,9 @@ class DeezerImage {
         this.type = type;
         //Create full and thumb, to standardize size and because functions aren't preserved
         this.full = DeezerImage.url(this.hash, this.type, 1400);
-        this.thumb = DeezerImage.url(this.hash, this.type, 256);
+        this.thumb = DeezerImage.url(this.hash, this.type, 264);
     }
-    static url(hash, type, size = 256) {
+    static url(hash, type, size = 264) {
         if (!hash)
             return `https://e-cdns-images.dzcdn.net/images/${type}/${size}x${size}-000000-80-0-0.jpg`;
         return `https://e-cdns-images.dzcdn.net/images/${type}/${hash}/${size}x${size}-000000-80-0-0.jpg`;


### PR DESCRIPTION
The new Deezer UI uses thumbnails of 264 px instead of 256 px, so I thought that was a good idea to use the same.