### PR TITLE
Readded Flow and implemented the Other Flow types

### DIFF
--- a/app/client/src/components/DeezerFlow.vue
+++ b/app/client/src/components/DeezerFlow.vue
@@ -1,0 +1,53 @@
+<template>
+<div>
+
+    <v-card max-width='175px' max-height='220px' height='220px' @click='play' :loading='loading' elevation='0' color='transparent'>
+        
+        <v-img v-if="stl.image && stl.image.thumb" :src='stl.image.thumb'>
+            <v-card-title class='font-weight-black text-truncate text-h6 pa-1 ps-3' style="text-shadow: 1.3px 1.3px 6px rgba(0, 0, 0, 0.65)">{{stl.title}}</v-card-title>
+        </v-img>
+
+        <div class='pa-2 text-subtitle-2'>{{stl.description}}</div>
+    </v-card>
+
+</div>
+</template>
+
+<script>
+export default {
+    name: 'DeezerFlow',
+    props: {
+        stl: Object
+    },
+    data() {
+        return {
+            loading: false
+        }
+    },
+    methods: {
+        //Load stt as source
+        async play() {
+            this.loading = true;
+            
+            //Load data
+            let res = await this.$axios.get('/smarttracklist/flow/' + this.stl.id);
+            if (!res.data) {
+                this.loading = false;
+                return;
+            }
+
+            //Send to player
+            this.$root.queue.source = {
+                text: this.stl.title,
+                source: 'smarttracklist',
+                data: this.stl.id,
+                type: 'flow'
+            };
+            this.$root.replaceQueue(res.data);
+            this.$root.playIndex(0);
+            
+            this.loading = false;
+        }
+    }
+}
+</script>

--- a/app/client/src/main.js
+++ b/app/client/src/main.js
@@ -433,10 +433,10 @@ new Vue({
         },
         //Load more SmartTrackList tracks
         async loadSTL() {
-            if (this.queue.data.length - 1 == this.queue.index && this.queue.source.source == 'smarttracklist') {
-                let data = await this.$axios.get('/smarttracklist/' + this.queue.source.data);
+            if (this.queue.data.length - 1 == this.queue.index && this.queue.source.source == 'smarttracklist' && this.queue.source.type && this.queue.source.type == 'flow') {
+                let data = await this.$axios.get('/smarttracklist/flow/' + this.queue.source.data);
                 if (data.data) {
-                    this.queue.data = this.queue.data.concat(data.data);
+                    this.replaceQueue(this.queue.data.concat(data.data));
                 }
                 this.savePlaybackInfo();
             }

--- a/app/client/src/views/DeezerPage.vue
+++ b/app/client/src/views/DeezerPage.vue
@@ -21,7 +21,8 @@
                     <ArtistTile v-if='item.type == "artist"' :artist='item.data' card></ArtistTile>
                     <DeezerChannel v-if='item.type == "channel"' :channel='item.data' class='mb-2'></DeezerChannel>
                     <AlbumTile v-if='item.type == "album"' :album='item.data' card></AlbumTile>
-                    <SmartTrackList v-if='item.type == "smarttracklist" || item.type == "flow"' :stl='item.data'></SmartTrackList>
+                    <SmartTrackList v-if='item.type == "smarttracklist"' :stl='item.data'></SmartTrackList>
+                    <DeezerFlow v-if='item.type == "flow"' :stl='item.data'></DeezerFlow>
                 </div>
                 <div v-if='section.hasMore' class='mx-2 align-center justify-center d-flex'>
                     <v-btn @click='showMore(section)' color='primary'>
@@ -38,7 +39,8 @@
                     <ArtistTile v-if='item.type == "artist"' :artist='item.data' card></ArtistTile>
                     <DeezerChannel v-if='item.type == "channel"' :channel='item.data' class='mb-2'></DeezerChannel>
                     <AlbumTile v-if='item.type == "album"' :album='item.data' card></AlbumTile>
-                    <SmartTrackList v-if='item.type == "smarttracklist" || item.type == "flow"' :stl='item.data'></SmartTrackList>
+                    <SmartTrackList v-if='item.type == "smarttracklist"' :stl='item.data'></SmartTrackList>
+                    <DeezerFlow v-if='item.type == "flow"' :stl='item.data'></DeezerFlow>
                 </div>
             </div>
 
@@ -54,10 +56,11 @@ import ArtistTile from '@/components/ArtistTile.vue';
 import DeezerChannel from '@/components/DeezerChannel.vue';
 import AlbumTile from '@/components/AlbumTile.vue';
 import SmartTrackList from '@/components/SmartTrackList.vue';
+import DeezerFlow from '../components/DeezerFlow.vue';
 
 export default {
     name: 'DeezerPage',
-    components: {PlaylistTile, ArtistTile, DeezerChannel, AlbumTile, SmartTrackList},
+    components: {PlaylistTile, ArtistTile, DeezerChannel, AlbumTile, SmartTrackList, DeezerFlow},
     props: {
         target: String
     },

--- a/app/src/definitions.js
+++ b/app/src/definitions.js
@@ -217,6 +217,16 @@ class SmartTrackList { // !
     }
 }
 
+class DeezerFlow {
+    constructor(json, target) {
+        this.title = json.title;
+        this.image = new DeezerImage(json.assets.dynamicPageIcon, json.__TYPE__);
+        this.id = json.id;
+        this.description = json.description;
+        this.target = target;
+    }
+}
+
 class DeezerPage {
     constructor(json) {
         this.title = json.title;
@@ -261,6 +271,8 @@ class ChannelSectionItem {
         //Parse data
         switch (this.type) {
             case 'flow':
+                this.data = new DeezerFlow(json.data, json.target);
+                break;
             case 'smarttracklist':
                 // console.log("smarttl: ", json.data) // Discover
                 this.data = new SmartTrackList(json.data);

--- a/app/src/definitions.js
+++ b/app/src/definitions.js
@@ -239,7 +239,9 @@ class ChannelSection {
     constructor(json) {
         //Parse layout
         switch (json.layout) {
+            case 'filterable-grid':
             case 'grid': this.layout = 'grid'; break;
+            case 'horizontal-list':
             case 'horizontal-grid': this.layout = 'row'; break;
             default: this.layout = 'row'; break;
         }
@@ -276,6 +278,11 @@ class ChannelSectionItem {
             case 'album':
                 this.data = new Album(json.data);
                 break;
+
+            // case 'track':
+            // case 'song':
+            //     this.data = new TrackMix(json.data);
+            //     break; 
         }
     }
 }

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -383,11 +383,12 @@ app.get('/page', async (req, res) => {
 });
 
 //Get smart track list or flow tracks
-app.get('/smarttracklist/:id', async (req, res) => {
+app.get('/smarttracklist/:type?/:id', async (req, res) => {
     let id = req.params.id;
-    
+    let type = req.params.type ? req.params.type : undefined;
+
     //Flow not normal STL
-    if (id == 'flow') {
+    if (id == 'flow' || type == 'flow') { // Not so clean check to know if it's flow
         let data = await deezer.callApi('radio.getUserRadio', {
             user_id: deezer.userId
         });

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -348,21 +348,33 @@ app.get('/stream/:info', async (req, res) => {
 
 //Get deezer page
 app.get('/page', async (req, res) => {
-    let target = req.query.target.replace(/"/g, '');
+    let target = req.query.target.replace(/'/g, '');
 
-    let st = ['album', 'artist', 'channel', 'flow', 'playlist', 'smarttracklist', 'track', 'user'];
+    let st = [ 'album', 'artist', 'artistLineUp', 'channel', 'livestream', 'flow', 'playlist', 'radio', 'show', 'smarttracklist', 'track', 'user', 'video-link', 'external-link' ];
     let data = await deezer.callApi('page.get', {}, {
         'PAGE': target,
-        'VERSION': '2.3',
+        'VERSION': '2.5',
         'SUPPORT': {
+            'ads': [ /* 'native' */ ], //None
+            'deeplink-list': [ 'deeplink' ],
+            'event-card': [ 'live-event' ],
+            'grid-preview-one': st,
+            'grid-preview-two': st,
             'grid': st,
             'horizontal-grid': st,
-            'item-highlight': ['radio'],
-            'large-card': ['album', 'playlist', 'show', 'video-link'],
-            'ads': [] //None
+            'horizontal-list': [ 'track', 'song' ],
+            'item-highlight': [ 'radio' ],
+            'large-card': ['album', 'external-link', 'playlist', 'show', 'video-link'],
+            'list': [ 'episode' ],
+            'message': [ 'call_onboarding' ],
+            'mini-banner': [ 'external-link' ],
+            'slideshow':        [ 'album', 'artist', 'channel', 'external-link', 'flow', 'livestream', 'playlist', 'show', 'smarttracklist', 'user', 'video-link' ],
+            'small-horizontal-grid': [ 'flow' ],
+            'long-card-horizontal-grid': st,
+            'filterable-grid': [ 'flow' ]
         },
         'LANG': settings.contentLanguage,
-        'OPTIONS': []
+        'OPTIONS': [ 'deeplink_newsandentertainment', 'deeplink_subscribeoffer' ]
     });
 
     // logger.warn("data", data.results)


### PR DESCRIPTION
Hello!
The new Deezer UI has updated some logic behind SmartTrackList (e.g. has a fixed number of tracks) and has new Flow types.
This patchs adds them, but needs some work to get a better UI on the Flows icons:
![immagine](https://github.com/user-attachments/assets/c1cde4f5-236d-45cf-b529-11bb97ba10a6)

On Deezer side they use an SVG circle with a centered PNG icon:
![immagine](https://github.com/user-attachments/assets/74d37381-729f-4382-822b-3a3f779f5da6)

I did't add it because I don't have much experience with Frontend Development and Web development in general (i'm not a professional).